### PR TITLE
Multistore saving issue

### DIFF
--- a/src/Block/Adminhtml/Category/Edit/Button/ViewInStore.php
+++ b/src/Block/Adminhtml/Category/Edit/Button/ViewInStore.php
@@ -77,8 +77,9 @@ class ViewInStore extends AbstractCategory implements ButtonProviderInterface
 
     private function getCategoryUrl()
     {
-        $category = $this->getCategory()->setStoreId($this->getCurrentStoreId());
-        return $category->getUrl();
+        $category = clone $this->getCategory();
+        $category->setStoreId($this->getCurrentStoreId());
+        return $category->getUrl($category);
     }
 
     private function getCurrentStoreId()

--- a/src/Block/Adminhtml/Product/Edit/Button/ViewInStore.php
+++ b/src/Block/Adminhtml/Product/Edit/Button/ViewInStore.php
@@ -73,7 +73,8 @@ class ViewInStore extends Generic
 
     private function getProductUrl()
     {
-        $product = $this->getProduct()->setStoreId($this->getCurrentStoreId());
+        $product = clone $this->getProduct();
+        $product->setStoreId($this->getCurrentStoreId());
         return $this->productUrl->getProductUrl($product);
     }
 


### PR DESCRIPTION
Clone the objects category and $product before setting the storeId so the All store View can be saved without redirecting to the default store view